### PR TITLE
product.env.in: Make it work with non-drm devices

### DIFF
--- a/base/startup/product.env.in
+++ b/base/startup/product.env.in
@@ -27,8 +27,6 @@ export QSG_TRANSIENT_IMAGES=1
 # Keymap
 export QT_QPA_EVDEV_KEYBOARD_PARAMETERS=keymap=@WEBOS_INSTALL_DATADIR@/webos-keymap/webos-keymap.qmap
 
-# Platform plugin to be used
-export WEBOS_COMPOSITOR_PLATFORM=eglfs
 
 # Cursor timeout
 export WEBOS_CURSOR_TIMEOUT=5000
@@ -52,6 +50,10 @@ if [ "$WEBOS_COMPOSITOR_DISPLAY_CONFIG" == "x" ]; then
     # DRM_PROBE_RETRY is valid only if DRM_CONNECTORS_EXPECTED > 0.
     # DRM_CONNECTORS_SCAN_PRIORITY is the list of connector names interested in order.
     # Use "*" to scan any connectors in alphabetical order.
+    
+    # Platform plugin to be used
+    export WEBOS_COMPOSITOR_PLATFORM=eglfs
+
     WEBOS_COMPOSITOR_DISPLAYS=0
     WEBOS_COMPOSITOR_PRIMARY_SCREEN=""
     DRM_PROBE_RETRY=10


### PR DESCRIPTION
Such as our Halium based targets which use hwcomposer.

Make sure to set WEBOS_COMPOSITOR_PLATFORM only in case the path exists, to avoid overriding the value provided in surface-manager.env

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>